### PR TITLE
fix: training program details

### DIFF
--- a/hrapp/templates/training_programs/training_program_list.html
+++ b/hrapp/templates/training_programs/training_program_list.html
@@ -16,27 +16,24 @@
 <h2>Upcoming Programs</h2>
 <ol class="training_programs">
     {% for training_program in all_training_programs %}
-    <li class="program">{{ training_program.title }}
-        <button class="tp_list_btn">
-            <a class="program__title" href="{% url 'hrapp:training_program' training_program.id %}">Details</a>
-        </button>
-
+    <li class="program">
+            <a class="program__title" href="{% url 'hrapp:training_program' training_program.id %}">{{ training_program.title }}</a>
     </li>
     {% endfor %}
 </ol>
+
 <h2>Past Programs</h2>
 <ol class="training_programs-past">
     {% for training_program in past_training_programs %}
     <li class="program__title">
-      {{ training_program.title }}
-        <button class="past_tp_btn">
-          <a href="{% url 'hrapp:training_program' training_program.id %}">Details</a>
-        </button>
+          <a href="{% url 'hrapp:training_program' training_program.id %}">{{ training_program.title }}</a>
     </li>
     {% endfor %}
 </ol>
+
 {% comment %} This part is for users with no authentication {% endcomment %}
 {% else %}
+
     <ol class="training_programs">
     {% for training_program in all_training_programs %}
     <li class="program">


### PR DESCRIPTION
Fixes #52 

# Fetching Instructions
```shell
git fetch --all
git checkout MC-training-program-details-button-52
```

# Description
Training program details button removed. The title of program is a hyper link in which user can click to navigate to the details for a specific training program.

# List of changes
- training_program_list.html


# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation specific to my parts
- [x] My changes generate no new warnings