### PR TITLE
fix: training programs forms extend base.html.

### DIFF
--- a/hrapp/templates/training_programs/training_program_form.html
+++ b/hrapp/templates/training_programs/training_program_form.html
@@ -1,12 +1,7 @@
+{% extends 'shared/base.html' %}
 {% load static %}
-<!DOCTYPE html>
-<html>
 
-<head>
-    <meta charset="utf-8">
-    <title>HR App</title>
-</head>
-
+{% block content %}
 <body>
     <h1>Training Program Form</h1>
 
@@ -68,5 +63,4 @@
 
     </form>
 </body>
-
-</html>
+{% endblock %}%}


### PR DESCRIPTION
Fixes #58 

# Fetching Instructions
```shell
git fetch --all
git checkout MC-training-programs-extend-base
```

# Description
added django script to extend base.html
# List of changes
- training_programs_form.html

# Checklist:
- [x] My code follows the style guidelines of this project
- [x]  I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation specific to my parts
- [x] My changes generate no new warnings